### PR TITLE
Add links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,5 @@ Suggests:
     rmarkdown,
     scales
 VignetteBuilder: knitr
+URL: https://alaninglis.github.io/colouR/, https://github.com/AlanInglis/colouR
+BugReports: https://github.com/AlanInglis/colouR/issues


### PR DESCRIPTION
To improve discoverability of the package!

You may consider adding the website`s link in the About page on Github
![image](https://github.com/AlanInglis/colouR/assets/52606734/66f14f45-fded-44aa-aec7-9c67bd375cb4)
